### PR TITLE
Map Method Refactor

### DIFF
--- a/scripts/retailer/RetailerList.js
+++ b/scripts/retailer/RetailerList.js
@@ -11,8 +11,8 @@ const contentTarget = document.querySelector("#retailersList");
 const headerContentTarget = document.querySelector("#retailersHeader");
 
 const render = (retailer, distributor, nurseries, flowers) => {
-    contentTarget.innerHTML += Retailer(retailer, distributor, nurseries, flowers)
-}
+    contentTarget.innerHTML += Retailer(retailer, distributor, nurseries, flowers);
+};
 
 export const RetailerList = () => {
     const arrayOfRetailerObjects = useRetailers();
@@ -22,22 +22,22 @@ export const RetailerList = () => {
     const arrayOfNurseryDistributorObjects = useNurseryDistributor();
     const arrayOfNurserFlowerObjects = useNurseryFlower();
     
-    headerContentTarget.innerHTML = `<h2 class="bold">Local Flower Retailers</h2>`
+    headerContentTarget.innerHTML = `<h2 class="bold">Local Flower Retailers</h2>`;
     arrayOfRetailerObjects.map(retailerObject => {
-        let foundNurseryFlowers = []
-        const foundDistributorObject = arrayOfDistributorObjects.find(distro => distro.id === retailerObject.distributorsID)
-        const foundNurseryDistributors = arrayOfNurseryDistributorObjects.filter(nurseryDistro => nurseryDistro.distributorId === foundDistributorObject.id)
+        const foundDistributorObject = arrayOfDistributorObjects.find(distro => distro.id === retailerObject.distributorsID);
+        const foundNurseryDistributors = arrayOfNurseryDistributorObjects.filter(nurseryDistro => nurseryDistro.distributorId === foundDistributorObject.id);
         const foundNurseries = foundNurseryDistributors.map(nurseryDistro => {
             return arrayOfNurseryObjects.find(nursery => nursery.id === nurseryDistro.nurseryId)
-        })
-        foundNurseries.forEach(foundNursery => {
-            arrayOfNurserFlowerObjects.filter(nurseryFlower => nurseryFlower.nurseryId === foundNursery.id).forEach(object => {
-                foundNurseryFlowers.push(object)
-            })
-        })
-        let foundFlowers = foundNurseryFlowers.map(nurseryFlower => {
-            return arrayOfFlowerObjects.find(flower => nurseryFlower.flowerId === flower.id)
-        })
-        render(retailerObject, foundDistributorObject, foundNurseries, foundFlowers)
-        })
-}
+        });
+        retailerObject.flowers = [];
+        foundNurseries.map(foundNursery => {
+            arrayOfNurserFlowerObjects.filter(nurseryFlower => nurseryFlower.nurseryId === foundNursery.id).map(nurseryFlower => {
+                let flowerObject = arrayOfFlowerObjects.find(flower => {
+                    return nurseryFlower.flowerId === flower.id
+                });
+                retailerObject.flowers.push(flowerObject);
+            });
+        });
+        render(retailerObject, foundDistributorObject, foundNurseries, retailerObject.flowers);
+        });
+};


### PR DESCRIPTION
### Changes
- Refactored to use map array method instead of forEach array method, due to the fact that we are converting an object into another object.
- Refactored RetailList function to immediately run a find array method on the join table resource when said resource is found, rather than storing that in a variable to be done later.
- End result is a more concise function.